### PR TITLE
Add missing 'libxt6' dependency of 'firefox-esr'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ RUN apt-get update \
  # Install dependencies for Firefox
  && apt-get install -y --no-install-recommends --no-install-suggests \
             `apt-cache depends firefox-esr | awk '/Depends:/{print$2}'` \
+            # additional 'firefox-esl' dependencies which is not in 'depends' list
+            libxt6 \
     \
  # Download and install Firefox
  && curl -fL -o /tmp/firefox.tar.bz2 \


### PR DESCRIPTION
Since [Build #94] `libxt6` is no longer installed automatically.
In last successful [Build #93] `libxt6` [was still installed][1] automatically

I get this error without `libxt6` installed:
```sh
$ docker run --rm --entrypoint sh instrumentisto/geckodriver:test -c '/opt/firefox/firefox'
XPCOMGlueLoad error for file /opt/firefox/libxul.so:
libXt.so.6: cannot open shared object file: No such file or directory
Couldn't load XPCOM.
```

It doesn't depend on version of `debian:buster-slim`. It was introduced by changes in [`firefox-esr`] package. But I haven't found these exact changes.     
I was able to reproduce this bug on stretch,  buster and  bullseye. It worked fine on jassie and sid.  This correlates with [package information][`firefox-esr`].  

FCM
```
Add missing 'libxt6' dependency of 'firefox-esr' (#1)
```

[`firefox-esr`]: https://packages.debian.org/buster/firefox-esr
[1]: https://travis-ci.org/github/instrumentisto/geckodriver-docker-image/builds/729608062#L378

 [Build #93]: https://travis-ci.org/github/instrumentisto/geckodriver-docker-image/builds/729608062
[Build #94]: https://travis-ci.org/github/instrumentisto/geckodriver-docker-image/builds/731547904