### PR TITLE
Set MOZ_HEADLESS=1 to avoid no display error (#3)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,11 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
            /tmp/*
 
+# As this image cannot run in non-headless mode anyway, it's better to forcibly
+# enable it, regardless whether WebDriver client requests it in capabilities or
+# not.
+ENV MOZ_HEADLESS=1
+
 EXPOSE 4444
 
 ENTRYPOINT ["geckodriver"]

--- a/README.md
+++ b/README.md
@@ -42,18 +42,6 @@ Consider using `--network=host` option for running image if you want to run test
 
 Consider to increase shared memory size (`--shm-size 2g` option), otherwise you may experience unexpected [Firefox] crashes.
 
-In case browser is not starting and crashing with similar error:
-
-```bash
-Error: no DISPLAY environment variable specified
-1610980807629   webdriver::server       DEBUG   <- 500 Internal Server Error {"value":{"error":"unknown error","message":"Process unexpectedly closed with status 1","stacktrace":""}}
-```
-
-Try setting `MOZ_HEADLESS` environment variable to `1`
-
-```bash
-docker run -d -p 4444:4444 -e MOZ_HEADLESS=1 instrumentisto/geckodriver
-```
 
 
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,18 @@ Consider using `--network=host` option for running image if you want to run test
 
 Consider to increase shared memory size (`--shm-size 2g` option), otherwise you may experience unexpected [Firefox] crashes.
 
+In case browser is not starting and crashing with similar error:
+
+```bash
+Error: no DISPLAY environment variable specified
+1610980807629   webdriver::server       DEBUG   <- 500 Internal Server Error {"value":{"error":"unknown error","message":"Process unexpectedly closed with status 1","stacktrace":""}}
+```
+
+Try setting `MOZ_HEADLESS` environment variable to `1`
+
+```bash
+docker run -d -p 4444:4444 -e MOZ_HEADLESS=1 instrumentisto/geckodriver
+```
 
 
 


### PR DESCRIPTION
This PR sets `MOZ_HEADLESS=1` env variable in `Dockerfile` to solve no display error

Closes https://github.com/instrumentisto/geckodriver-docker-image/issues/3